### PR TITLE
uvicorn 0.20.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,14 @@ build:
   number: 0
   skip: true  # [py<38]
 
+requirements:
+  host:
+    - python
+    - pip
+    - hatchling
+    - setuptools
+    - wheel
+
 outputs:
   - name: uvicorn
     script: uvicorn_build.bat  # [win]
@@ -32,10 +40,10 @@ outputs:
         - click >=7.*
         - h11 >=0.8
     test:
-      requires:
-        - pip
       imports:
         - uvicorn
+      requires:
+        - pip
       commands:
         - pip check
         - uvicorn --help
@@ -51,12 +59,13 @@ outputs:
       run:
         - {{ pin_subpackage('uvicorn', exact=True) }}
         - colorama >=0.4  # [win]
-        # TODO: add httptools, websockets, watchfiles, and update uvloop
         - httptools >=0.5.0
         - python-dotenv >=0.13
         - PyYAML >=5.1
         - uvloop >=0.14.0,!=0.15.0,!=0.15.1  # [not win]
-        - watchfiles >=0.13
+        # TODO: add watchfiles for win-64.
+        # 2023/03/02: There were CI issues with building watchfiles on Windows related to python executables. 
+        - watchfiles >=0.13  # [not win]
         - websockets >=10.4
     test:
       requires:
@@ -64,7 +73,7 @@ outputs:
       commands:
         - pip check
       imports:
-        - uvicorn.supervisors.watchfilesreload  # [python_impl == "cpython"]
+        - uvicorn.supervisors.watchfilesreload
 
 about:
   home: https://github.com/encode/uvicorn

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,8 +51,8 @@ outputs:
   - name: uvicorn-standard
     build:
       skip: true  # [py<38]
-      # watchfiles is missing on s390x
-      skip: true  # [s390x]
+      # watchfiles is missing on s390x and win-64
+      skip: true  # [s390x or win]
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,8 @@ outputs:
   - name: uvicorn-standard
     build:
       skip: true  # [py<38]
+      # watchfiles is missing on s390x
+      skip: true  # [s390x]
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,46 +1,77 @@
-{% set version = "0.16.0" %}
+{% set version = "0.20.0" %}
 
 package:
-  name: uvicorn
+  name: uvicorn-split
   version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/u/uvicorn/uvicorn-{{ version }}.tar.gz
-  sha256: eacb66afa65e0648fcbce5e746b135d09722231ffffc61883d4fac2b62fbea8d
+  sha256: a4e12017b940247f836bc90b72e725d7dfd0c8ed1c51eb365f5ba30d9f5127d8
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-  entry_points:
-    - uvicorn = uvicorn.main:main
-  skip: true # [py<=37]
+  skip: true  # [py<38]
 
-requirements:
-  host:
-    - python
-    - pip
-  run:
-    - python
-    - asgiref >=3.4.0
-    - click >=7.*
-    - h11 >=0.8
-    - typing-extensions  # [py<38]
+outputs:
+  - name: uvicorn
+    script: uvicorn_build.bat  # [win]
+    script: uvicorn_build.sh  # [not win]
+    build:
+      skip: true  # [py<38]
+      entry_points:
+        - uvicorn = uvicorn.main:main
+    requirements:
+      host:
+        - python
+        - pip
+        - hatchling
+        - setuptools
+        - wheel
+      run:
+        - python
+        - click >=7.*
+        - h11 >=0.8
+    test:
+      requires:
+        - pip
+      imports:
+        - uvicorn
+      commands:
+        - pip check
+        - uvicorn --help
 
-test:
-  requires:
-    - pip
-  imports:
-    - uvicorn
-  commands:
-    - pip check
-    - uvicorn --help
+  - name: uvicorn-standard
+    build:
+      skip: true  # [py<38]
+    requirements:
+      host:
+        - python
+        - pip
+        - {{ pin_subpackage('uvicorn', exact=True) }}
+      run:
+        - {{ pin_subpackage('uvicorn', exact=True) }}
+        - colorama >=0.4  # [win]
+        # TODO: add httptools, websockets, watchfiles, and update uvloop
+        - httptools >=0.5.0
+        - python-dotenv >=0.13
+        - PyYAML >=5.1
+        - uvloop >=0.14.0,!=0.15.0,!=0.15.1  # [not win]
+        - watchfiles >=0.13
+        - websockets >=10.4
+    test:
+      requires:
+        - pip
+      commands:
+        - pip check
+      imports:
+        - uvicorn.supervisors.watchfilesreload  # [python_impl == "cpython"]
 
 about:
   home: https://github.com/encode/uvicorn
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.md
-  summary: The lightning-fast ASGI server. 🦄
+  summary: The lightning-fast ASGI server.
   description: |
     Uvicorn is a lightning-fast ASGI server implementation,
     using [uvloop](https://github.com/MagicStack/uvloop) and
@@ -49,6 +80,7 @@ about:
   dev_url: https://github.com/encode/uvicorn
 
 extra:
+  feedstock-name: uvicorn
   recipe-maintainers:
     - carlodri
     - ocefpaf

--- a/recipe/uvicorn_build.bat
+++ b/recipe/uvicorn_build.bat
@@ -1,0 +1,1 @@
+%PYTHON% -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/uvicorn_build.sh
+++ b/recipe/uvicorn_build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash -eux
+${PYTHON} -m pip install . --no-deps --no-build-isolation -vv


### PR DESCRIPTION
Changelog: https://github.com/encode/uvicorn/blob/0.20.0/CHANGELOG.md
License: https://github.com/encode/uvicorn/blob/0.20.0/LICENSE.md
Requirements: 
- https://github.com/encode/uvicorn/blob/0.20.0/pyproject.toml
- https://github.com/encode/uvicorn/blob/0.20.0/requirements.txt
- https://github.com/encode/uvicorn/blob/0.20.0/setup.py

Actions:
1. Split the package to subpackages
2. Skip `py<38`
3. Make the general `host` section 
4. Skip building `uvicorn-standard` on `s390x` and `win` because `watchfiles` is missing
5. Temporarily constrain `watchfiles` with `# [not win]`, because of CI issues.  `uvicorn-standard` isn't required by downstream packages so we can skip `win-64` now
6. Add build scripts for win and unix.