### PR TITLE
[PKG-5399] 0.30.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,7 @@ outputs:
         - uvloop >=0.14.0,!=0.15.0,!=0.15.1  # [not win]
         # TODO: add watchfiles for win-64.
         # 2023/03/02: There were CI issues with building watchfiles on Windows related to python executables. 
-        - watchfiles >=0.13
+        - watchfiles >=0.13  # [py<312 or not ((osx and x86) or linux64 or aarch64)]
         - websockets >=10.4
     test:
       source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,8 +5,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/u/uvicorn/uvicorn-{{ version }}.tar.gz
-  sha256: a4e12017b940247f836bc90b72e725d7dfd0c8ed1c51eb365f5ba30d9f5127d8
+  url: https://github.com/encode/uvicorn/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 2b39d8391344132690e2cb96ba760bfc41e0fd577c70cf3bad210217704f1701
 
 build:
   number: 0
@@ -69,10 +69,20 @@ outputs:
         - watchfiles >=0.13
         - websockets >=10.4
     test:
+      source_files:
+        - pyproject.toml
+        - tests
       requires:
         - pip
+        - pytest
+        - pytest-mock
+        - httpx
+        - wsproto
+        #- trustme
       commands:
         - pip check
+        - pytest --ignore="tests/middleware/test_wsgi.py" --ignore="tests/test_server.py" --ignore="tests/supervisors/test_signal.py" -k "not (socket_bind or config_log_effective_level)"
+
       imports:
         - uvicorn.supervisors.watchfilesreload
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,8 +31,6 @@ outputs:
         - python
         - pip
         - hatchling
-        - setuptools
-        - wheel
       run:
         - python
         - click >=7.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,10 +74,18 @@ outputs:
         - pytest-mock
         - httpx
         - wsproto
-        #- trustme
+        - trustme
+
+      {% set pytest_ignore = '--ignore="tests/middleware/test_wsgi.py"' %}
+      {% set pytest_ignore = pytest_ignore + ' --ignore="tests/supervisors/test_signal.py"' %}
+      {% set pytest_ignore = pytest_ignore + ' --ignore="tests/test_server.py"' %}
+
+      {% set pytest_skip = "socket_bind" %}
+      {% set pytest_skip = pytest_skip + " or config_log_effective_level" %}
+
       commands:
         - pip check
-        - pytest --ignore="tests/middleware/test_wsgi.py" --ignore="tests/test_server.py" --ignore="tests/supervisors/test_signal.py" -k "not (socket_bind or config_log_effective_level)"
+        - pytest {{ pytest_ignore }} -k "not ({{ pytest_skip }})"
 
       imports:
         - uvicorn.supervisors.watchfilesreload

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.20.0" %}
+{% set version = "0.30.6" %}
 
 package:
   name: uvicorn-split
@@ -17,8 +17,6 @@ requirements:
     - python
     - pip
     - hatchling
-    - setuptools
-    - wheel
 
 outputs:
   - name: uvicorn
@@ -39,6 +37,7 @@ outputs:
         - python
         - click >=7.*
         - h11 >=0.8
+        - typing_extensions >=4.0  # [py<311]
     test:
       imports:
         - uvicorn
@@ -67,7 +66,7 @@ outputs:
         - uvloop >=0.14.0,!=0.15.0,!=0.15.1  # [not win]
         # TODO: add watchfiles for win-64.
         # 2023/03/02: There were CI issues with building watchfiles on Windows related to python executables. 
-        - watchfiles >=0.13  # [not win]
+        - watchfiles >=0.13
         - websockets >=10.4
     test:
       requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,9 +64,8 @@ outputs:
         - python-dotenv >=0.13
         - PyYAML >=5.1
         - uvloop >=0.14.0,!=0.15.0,!=0.15.1  # [not win]
-        # TODO: add watchfiles for win-64.
-        # 2023/03/02: There were CI issues with building watchfiles on Windows related to python executables. 
-        - watchfiles >=0.13  # [py<312 or not ((osx and x86) or linux64 or aarch64)]
+        - watchfiles >=0.13  # [py<312]
+        - watchfiles >=0.13  # [py>311 and not ((osx and x86) or linux64 or aarch64)]
         - websockets >=10.4
     test:
       source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ outputs:
   - name: uvicorn-standard
     build:
       # s390x missing watchfiles
-      skip: true  # [py<38 or py>311 or s390x]
+      skip: true  # [py<38 or s390x]
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ outputs:
         - hatchling
       run:
         - python
-        - click >=7.*
+        - click >=7.0
         - h11 >=0.8
         - typing_extensions >=4.0  # [py<311]
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,7 +87,7 @@ outputs:
 
       commands:
         - pip check
-        - pytest {{ pytest_ignore }} -k "not ({{ pytest_skip }})"
+        - pytest -v {{ pytest_ignore }} -k "not ({{ pytest_skip }})"
 
       imports:
         - uvicorn.supervisors.watchfilesreload

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,9 +49,7 @@ outputs:
 
   - name: uvicorn-standard
     build:
-      skip: true  # [py<38]
-      # watchfiles is missing on s390x and win-64
-      skip: true  # [s390x or win]
+      skip: true  # [py<38 or py>311]
     requirements:
       host:
         - python
@@ -64,8 +62,7 @@ outputs:
         - python-dotenv >=0.13
         - PyYAML >=5.1
         - uvloop >=0.14.0,!=0.15.0,!=0.15.1  # [not win]
-        - watchfiles >=0.13  # [py<312]
-        - watchfiles >=0.13  # [py>311 and not ((osx and x86) or linux64 or aarch64)]
+        - watchfiles >=0.13
         - websockets >=10.4
     test:
       source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,7 +87,8 @@ outputs:
 
       commands:
         - pip check
-        - pytest -v {{ pytest_ignore }} -k "not ({{ pytest_skip }})"
+        - pytest -v {{ pytest_ignore }} -k "not ({{ pytest_skip }})"  # [not (osx and x86)]
+        - pytest -v {{ pytest_ignore }} -k "not ({{ pytest_skip }})" -m "not reloader_class"  # [osx and x86]
 
       imports:
         - uvicorn.supervisors.watchfilesreload

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,8 @@ outputs:
 
   - name: uvicorn-standard
     build:
-      skip: true  # [py<38 or py>311]
+      # s390x missing watchfiles
+      skip: true  # [py<38 or py>311 or s390x]
     requirements:
       host:
         - python
@@ -82,6 +83,7 @@ outputs:
 
       {% set pytest_skip = "socket_bind" %}
       {% set pytest_skip = pytest_skip + " or config_log_effective_level" %}
+      {% set pytest_skip = pytest_skip + " or test_run" %}
 
       commands:
         - pip check


### PR DESCRIPTION
uvicorn 0.30.6

**Destination channel:** defaults

### Links

- [PKG-5399]
- [Upstream repository](https://github.com/encode/uvicorn)

### Explanation of changes:

- Added upstream tests.
  - `reloader_class` tests fail on osx-64. It appears they are [skipped by upstream for osx-arm64](https://github.com/encode/uvicorn/blob/7dc027d5fb980c7bd52ab4611f3109a796cec974/tests/supervisors/test_reload.py#L29-L33), so I'm guessing this is related.
  - The other skipped tests have networking issues on the CI.

[PKG-5399]: https://anaconda.atlassian.net/browse/PKG-5399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ