### PR TITLE
uvicorn 0.40.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/watchfiles-feedstock/pr13/dbb0c4e

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/watchfiles-feedstock/pr13/dbb0c4e

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<39]
+  skip: true  # [py<310]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,13 +86,20 @@ outputs:
         - watchfiles >=0.13
         - websockets >=10.4
 
+    {% set ignore_tests = '' %}
     # >       from websockets.server import ServerProtocol
     # E       ImportError: cannot import name 'ServerProtocol' from 'websockets.server'
     # https://github.com/python-websockets/websockets/blob/13.1/src/websockets/server.py#L48
     # Needs websockets >=13.1
-    {% set ignore_tests = ' --ignore="tests/protocols/test_websocket.py"' %}
+    {% set ignore_tests = ignore_tests + ' --ignore="tests/protocols/test_websocket.py"' %}
     {% set ignore_tests = ignore_tests + ' --ignore="tests/middleware/test_logging.py"' %}
     {% set ignore_tests = ignore_tests + ' --ignore="tests/middleware/test_message_logger.py"' %}
+    # tests/supervisors/test_multiprocess.py and tests/supervisors/test_reload.py are flaky on Windows and MacOS.
+    # Exit code 0xC000013A (STATUS_CONTROL_C_EXIT) during pytest-xdist worker teardown, not during actual test execution. 
+    # The 69% completion shows tests were passing, then cleanup timed out trying to terminate parallel workers.
+    {% set ignore_tests = ignore_tests + ' --ignore="tests/supervisors/test_multiprocess.py"' %}
+    {% set ignore_tests = ignore_tests + ' --ignore="tests/supervisors/test_reload.py"' %}
+
     {% set tests_to_skip = " test_http2_upgrade_request " %}
     {% set tests_to_skip = tests_to_skip + " or test_proxy_headers_websocket_x_forwarded_proto " %}
     # Needs a2wsgi >=1.10.8
@@ -115,22 +122,17 @@ outputs:
         - uvicorn.middleware.message_logger
         - uvicorn.protocols.http.httptools_impl
         - uvicorn.protocols.websockets.websockets_impl
-      commands:
-        - pip check
-        - pytest -v {{ ignore_tests }} -k "not ({{ tests_to_skip }})"  # [not win]
-        # Exit code 0xC000013A (STATUS_CONTROL_C_EXIT) during pytest-xdist worker teardown, not during actual test execution. 
-        #The 69% completion shows tests were passing, then cleanup timed out trying to terminate parallel workers.
-        # Eliminating parallel worker cleanup issues entirely. 
-        # Single-process testing is more reliable on Windows for async codebases.
-        - pytest -v {{ ignore_tests }} -k "not ({{ tests_to_skip }})"  # [win]
       requires:
         - pip
         - pytest >=8.3.5
         - pytest-mock >=3.14.0
-        - pytest-xdist >=3.6.1  # [not win]
+        - pytest-xdist >=3.6.1
         - wsproto
         - httpx >=0.28.1
         - trustme >=1.2.1
+      commands:
+        - pip check
+        - pytest -v {{ ignore_tests }} -k "not ({{ tests_to_skip }})"
 
 about:
   home: https://github.com/encode/uvicorn

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,6 +87,7 @@ outputs:
         - websockets >=10.4
 
     {% set ignore_tests = '' %}
+    {% set tests_to_skip = '' %}
     # >       from websockets.server import ServerProtocol
     # E       ImportError: cannot import name 'ServerProtocol' from 'websockets.server'
     # https://github.com/python-websockets/websockets/blob/13.1/src/websockets/server.py#L48
@@ -100,7 +101,7 @@ outputs:
     {% set ignore_tests = ignore_tests + ' --ignore="tests/supervisors/test_multiprocess.py"' %}  # [not linux]
     {% set ignore_tests = ignore_tests + ' --ignore="tests/supervisors/test_reload.py"' %}  # [not linux]
 
-    {% set tests_to_skip = " test_http2_upgrade_request " %}
+    {% set tests_to_skip = tests_to_skip + " test_http2_upgrade_request " %}
     {% set tests_to_skip = tests_to_skip + " or test_proxy_headers_websocket_x_forwarded_proto " %}
     # Needs a2wsgi >=1.10.8
     {% set ignore_tests = ignore_tests + ' --ignore="tests/middleware/test_wsgi.py"' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -117,7 +117,12 @@ outputs:
         - uvicorn.protocols.websockets.websockets_impl
       commands:
         - pip check
-        - pytest -v {{ ignore_tests }} -k "not ({{ tests_to_skip }})"
+        - pytest -v {{ ignore_tests }} -k "not ({{ tests_to_skip }})"  # [not win]
+        # Exit code 0xC000013A (STATUS_CONTROL_C_EXIT) during pytest-xdist worker teardown, not during actual test execution. 
+        #The 69% completion shows tests were passing, then cleanup timed out trying to terminate parallel workers.
+        # Eliminating parallel worker cleanup issues entirely. 
+        # Single-process testing is more reliable on Windows for async codebases.
+        - pytest -v -n0 {{ ignore_tests }} -k "not ({{ tests_to_skip }})"  # [win]
       requires:
         - pip
         - pytest >=8.3.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,6 +103,8 @@ outputs:
     # E    +  where None = _reload_tester(<function touch_soon.<locals>.start at 0x112907430>, <uvicorn.supervisors.watchfilesreload.WatchFilesReload object at 0x11244d220>, PosixPath('/private/var/folders/c_/qfmhj66j0tn016nkx_th4hxm0000gp/T/pytest-of-builder/pytest-923/popen-gw4/reload_directory0/app/sub/sub.py'))
     #      +    where _reload_tester = <tests.supervisors.test_reload.TestBaseReload object at 0x1120d7130>._reload_tester
     {% set tests_to_skip = tests_to_skip + " or TestBaseReload " %}  # [osx]
+    # EOFError: Ran out of input
+    {% set tests_to_skip = tests_to_skip + " or test_multiprocess_health_check " %}  # [linux]
 
     test:
       source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -97,8 +97,8 @@ outputs:
     # tests/supervisors/test_multiprocess.py and tests/supervisors/test_reload.py are flaky on Windows and MacOS.
     # Exit code 0xC000013A (STATUS_CONTROL_C_EXIT) during pytest-xdist worker teardown, not during actual test execution. 
     # The 69% completion shows tests were passing, then cleanup timed out trying to terminate parallel workers.
-    {% set ignore_tests = ignore_tests + ' --ignore="tests/supervisors/test_multiprocess.py"' %}
-    {% set ignore_tests = ignore_tests + ' --ignore="tests/supervisors/test_reload.py"' %}
+    {% set ignore_tests = ignore_tests + ' --ignore="tests/supervisors/test_multiprocess.py"' %}  # [not linux]
+    {% set ignore_tests = ignore_tests + ' --ignore="tests/supervisors/test_reload.py"' %}  # [not linux]
 
     {% set tests_to_skip = " test_http2_upgrade_request " %}
     {% set tests_to_skip = tests_to_skip + " or test_proxy_headers_websocket_x_forwarded_proto " %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -127,7 +127,7 @@ outputs:
         - pip
         - pytest >=8.3.5
         - pytest-mock >=3.14.0
-        - pytest-xdist >=3.6.1
+        - pytest-xdist >=3.6.1  # [not win]
         - wsproto
         - httpx >=0.28.1
         - trustme >=1.2.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "uvicorn" %}
-{% set version = "0.35.0" %}
+{% set version = "0.40.0" %}
 
 package:
   name: {{ name|lower }}-split
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/encode/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 61f096928e6cb320c58e577d0b38db62558d1f5ef13145ad1095350ef84f85e9
+  sha256: 8718fbab752726670235c574d0f73f540aceca69e2692c2f2f8f2b1f8f0d6df5
 
 build:
   number: 0
@@ -81,7 +81,7 @@ outputs:
         - colorama >=0.4  # [win]
         - httptools >=0.6.3
         - python-dotenv >=0.13
-        - PyYAML >=5.1
+        - pyyaml >=5.1
         - uvloop >=0.14.0,!=0.15.0,!=0.15.1  # [not win]
         - watchfiles >=0.13
         - websockets >=10.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -122,7 +122,7 @@ outputs:
         #The 69% completion shows tests were passing, then cleanup timed out trying to terminate parallel workers.
         # Eliminating parallel worker cleanup issues entirely. 
         # Single-process testing is more reliable on Windows for async codebases.
-        - pytest -v -n0 {{ ignore_tests }} -k "not ({{ tests_to_skip }})"  # [win]
+        - pytest -v {{ ignore_tests }} -k "not ({{ tests_to_skip }})"  # [win]
       requires:
         - pip
         - pytest >=8.3.5


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-11842) 
- [Upstream repository](https://github.com/encode/uvicorn/tree/0.40.0)

### Explanation of changes:

- Skip a problematic test on Linux and flaky tests on Windows & macOS. 

### Notes:

- Updating for fastapi https://github.com/AnacondaRecipes/fastapi-feedstock/pull/8